### PR TITLE
title gradient remove

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -160,7 +160,7 @@ h2 {
     left: 0px;
 }
 [data-theme='dark'] .RadialGradient:before {
-    position: absolute;
+    /* position: absolute;
     top: auto;
     right: auto;
     bottom: auto;
@@ -170,13 +170,12 @@ h2 {
     width: 100%;
     height: 569px;
     left: -100px;
-    /*transform: matrix(0, 1, -1, 0, 0, 0);*/
     background: transparent -webkit-radial-gradient(50% 50%, closest-side, #fa45c1 0%, #cb389d 21%, #571843 67%, #000000 100%) 0% 0% no-repeat padding-box;
     background: transparent -o-radial-gradient(50% 50%, closest-side, #fa45c1 0%, #cb389d 21%, #571843 67%, #000000 100%) 0% 0% no-repeat padding-box;
     background: transparent radial-gradient(closest-side at 50% 50%, #fa45c1 0%, #cb389d 21%, #571843 67%, #000000 100%) 0% 0% no-repeat padding-box;
     mix-blend-mode: color-dodge;
     opacity: 0.42;
-    z-index: 0;
+    z-index: 0; */
 }
 
 [data-theme='dark'] .RadialGradient.top-minus:before {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request adjusts the CSS positioning of class "RadialGradient" in the dark theme, setting the z-index to 0 while removing absolute positioning.

**Key Points**

* Removes absolute positioning of "RadialGradient" class in dark theme
* Sets z-index to 0 for "RadialGradient" class in dark theme. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>